### PR TITLE
Ignore main branch for action to create tokens

### DIFF
--- a/.github/workflows/create-usable-tokens.yml
+++ b/.github/workflows/create-usable-tokens.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push]
+on: 
+  push:
+    branches-ignore:
+      - 'main'
 
 jobs:
   build:

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 08 Nov 2021 16:37:20 GMT
+// Generated on Tue, 09 Nov 2021 16:13:57 GMT
 
 $layout-09: 128;
 $layout-08: 112;


### PR DESCRIPTION
We do not want this action to run on the main branch. The main branch should be ignored for the action to create usable tokens. 

Before ignoring the main branch there was an error with the build since main is a protected branch:
```remote: error: GH006: Protected branch update failed for refs/heads/main. ```

The action to create usable tokens should not produce an error after this is merged.