### PR TITLE
Update box shadow tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -189,24 +189,25 @@
       "type": "borderRadius"
     },
     "shadow-01": {
-      "value": {
-        "y": "1",
-        "blur": "2",
-        "color": "rgba(0, 0, 0, 0.04)",
-        "x": "0",
-        "spread": "0"
-      },
+      "value": [
+        {
+          "y": "1",
+          "blur": "2",
+          "color": "rgba(0, 0, 0, 0.04)",
+          "x": "0",
+          "spread": "0",
+          "type": "dropShadow"
+        },
+        {
+          "x": "0",
+          "y": "6",
+          "blur": "32",
+          "spread": "0",
+          "color": "rgba(0,0,0, 0.08)",
+          "type": "dropShadow"
+        }
+      ],
       "description": "Usage: card hover  Keywords:",
-      "type": "boxShadow"
-    },
-    "shadow-02": {
-      "value": {
-        "x": "0",
-        "y": "6",
-        "blur": "32",
-        "spread": "0",
-        "color": "rgba(0, 0, 0, 0.08)"
-      },
       "type": "boxShadow"
     },
     "lightbox-01": {
@@ -215,7 +216,8 @@
         "y": "8",
         "blur": "32",
         "spread": "0",
-        "color": "rgba(0, 0, 0, 0.18)"
+        "color": "rgba(0, 0, 0, 0.18)",
+        "type": "dropShadow"
       },
       "description": "Usage: lightbox Keywords:",
       "type": "boxShadow"
@@ -226,7 +228,7 @@
         "y": "2",
         "blur": "8",
         "spread": "0",
-        "color": "$secondary.grey04, .08"
+        "color": "rgba($secondary.grey-04, .08)"
       },
       "description": "Usage: navigation Keywords: ",
       "type": "boxShadow"
@@ -319,6 +321,17 @@
     "layout-09": {
       "value": "128",
       "type": "spacing"
+    },
+    "search-01": {
+      "value": {
+        "x": "0",
+        "y": "10",
+        "blur": "17",
+        "spread": "0",
+        "color": "rgba(0,0,0,0.04)",
+        "type": "dropShadow"
+      },
+      "type": "boxShadow"
     }
   },
   "typography": {

--- a/data/transformed-tokens.json
+++ b/data/transformed-tokens.json
@@ -188,24 +188,25 @@
     "type": "borderRadius"
   },
   "shadow-01": {
-    "value": {
-      "y": 1,
-      "blur": 2,
-      "color": "#0000000a",
-      "x": 0,
-      "spread": 0
-    },
+    "value": [
+      {
+        "y": 1,
+        "blur": 2,
+        "color": "#0000000a",
+        "x": 0,
+        "spread": 0,
+        "type": "dropShadow"
+      },
+      {
+        "x": 0,
+        "y": 6,
+        "blur": 32,
+        "spread": 0,
+        "color": "#00000014",
+        "type": "dropShadow"
+      }
+    ],
     "description": "Usage: card hover  Keywords:",
-    "type": "boxShadow"
-  },
-  "shadow-02": {
-    "value": {
-      "x": 0,
-      "y": 6,
-      "blur": 32,
-      "spread": 0,
-      "color": "#00000014"
-    },
     "type": "boxShadow"
   },
   "lightbox-01": {
@@ -214,7 +215,8 @@
       "y": 8,
       "blur": 32,
       "spread": 0,
-      "color": "#0000002e"
+      "color": "#0000002e",
+      "type": "dropShadow"
     },
     "description": "Usage: lightbox Keywords:",
     "type": "boxShadow"
@@ -225,7 +227,7 @@
       "y": 2,
       "blur": 8,
       "spread": 0,
-      "color": "$secondary.grey04, .08"
+      "color": "#71717114"
     },
     "description": "Usage: navigation Keywords: ",
     "type": "boxShadow"
@@ -318,5 +320,16 @@
   "layout-09": {
     "value": 128,
     "type": "spacing"
+  },
+  "search-01": {
+    "value": {
+      "x": 0,
+      "y": 10,
+      "blur": 17,
+      "spread": 0,
+      "color": "#0000000a",
+      "type": "dropShadow"
+    },
+    "type": "boxShadow"
   }
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,7 +1,8 @@
 
 // Do not edit directly
-// Generated on Thu, 02 Dec 2021 16:16:03 GMT
+// Generated on Fri, 03 Dec 2021 22:02:12 GMT
 
+$search-01: [object Object];
 $layout-09: 128;
 $layout-08: 112;
 $layout-07: 96;
@@ -25,8 +26,7 @@ $paragraph-spacing-0: 0;
 $overlays-overlay-02: linear-gradient(90deg, #0f0f0f00 0%, #0f0f0f40 67.57%, #0f0f0f 100%);
 $navigation-01: [object Object];
 $lightbox-01: [object Object];
-$shadow-02: [object Object];
-$shadow-01: [object Object];
+$shadow-01: [object Object],[object Object];
 $rounded-slightly: 4;
 $gradients-gradient-02: linear-gradient(260deg, #0b6ab7 7.91%, #1f75c5 35.23%, #0aa5ff 81.77%);
 $gradients-gradient-01: linear-gradient(52deg, #0b6ab7 0%, #1f75c5 41.67%, #0aa5ff 93.36%);


### PR DESCRIPTION
This updates the tokens in the figma plugin which now allows multiple drop shadows per token. However, the compiled scss file is still producing an undesired output `[object Object]` for box shadows.