### PR TITLE
feat: push assets to hosted-assets repo

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -1,10 +1,10 @@
-name: Release
+name: Publish assets
 on:
   push:
     branches: [main, beta]
 jobs:
   release:
-    name: Release
+    name: Publish to NPM
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,3 +23,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+    # Adds files in assets/ to hosted-assets repo
+      - name: Push assets/ to hosted-assets repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'assets/'
+          destination-github-username: 'UCLALibrary'
+          destination-repository-name: 'hosted-assets'
+          user-email: aliauw@library.ucla.edu
+          target-branch: main
+          target-directory: 'assets/'

--- a/scss/_tokens.scss
+++ b/scss/_tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 26 Jul 2022 02:48:28 GMT
+// Generated on Wed, 27 Jul 2022 14:27:05 GMT
 
 $status-error-02: #B3070D;
 $status-error-01: #FAD3CF;


### PR DESCRIPTION
netlify allows only one repo as the source. this github action's job attempts to copy the assets directory and pushes it to the hosted-assets (formerly springshare) repo. we will use the hosted-assets repo as the source for netlify. 