### PR TITLE
style: add styles for ftva-fpb rich text h3 h4 h5

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -35,18 +35,18 @@
 }
 
 @mixin card-horizontal-hover {
-    transform: $transform-zoom-hover;
-    @include shadow-state-change;
+  transform: $transform-zoom-hover;
+  @include shadow-state-change;
 }
 
 @mixin card-vertical-hover {
-    transform: $transform-zoom-hover-l;
-    @include shadow-state-change;
+  transform: $transform-zoom-hover-l;
+  @include shadow-state-change;
 }
 
-@mixin  animate-normal {
-    transition-duration: $transition-timing-normal;
-    transition-timing-function: $transition-easing;
+@mixin animate-normal {
+  transition-duration: $transition-timing-normal;
+  transition-timing-function: $transition-easing;
 }
 
 @mixin visually-hidden {
@@ -86,12 +86,12 @@
 }
 
 @mixin overline {
-    font-family: $font-primary;
-    font-size: var(--step--1);
-    font-weight: $font-weight-medium;
-    line-height: $line-height--2;
-    letter-spacing: $letter-spacing-2;
-    text-transform: uppercase;
+  font-family: $font-primary;
+  font-size: var(--step--1);
+  font-weight: $font-weight-medium;
+  line-height: $line-height--2;
+  letter-spacing: $letter-spacing-2;
+  text-transform: uppercase;
 }
 
 @mixin step--1 {
@@ -187,6 +187,27 @@
   line-height: 110%;
 }
 
+@mixin ftva-fpb-rich-text-h3 {
+  font-family: $font-primary;
+  font-size: 36px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h4 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-medium;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h5 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
+}
+
 @mixin ftva-card-title-1 {
   font-family: $font-primary;
   font-size: 30px;
@@ -230,14 +251,14 @@
   font-family: $font-secondary;
   font-size: 18px;
   font-weight: $font-weight-regular;
-  line-height: 150%; 
+  line-height: 150%;
 }
 
 @mixin ftva-body-2 {
   font-family: $font-secondary;
   font-size: 16px;
   font-weight: $font-weight-regular;
-  line-height: 150%; 
+  line-height: 150%;
 }
 
 @mixin button {
@@ -305,7 +326,7 @@
   font-family: $font-primary;
   font-size: 16px;
   font-weight: $font-weight-regular;
-  line-height: 140%; 
+  line-height: 140%;
   letter-spacing: 0.64px;
   text-transform: uppercase;
 }
@@ -344,8 +365,8 @@
 }
 
 @mixin truncate($lines: 2) {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: $lines;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
 }


### PR DESCRIPTION
This PR adds specific styles for the FPB rich text h3,h4,& h5 headings.
It will be included on the FTVA pages the have FPBs

```css

@mixin ftva-fpb-rich-text-h3 {
  font-family: $font-primary;
  font-size: 36px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h4 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-medium;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h5 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}
```

<img width="883" height="422" alt="Screenshot 2025-10-01 at 5 16 23 PM" src="https://github.com/user-attachments/assets/0186097e-9335-4354-89be-0f0be2afa65c" />
