### PR TITLE
feat: add styles for ftva-fpb rich text h3 h4 h5

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -187,6 +187,7 @@
   line-height: 110%;
 }
 
+// Flexible Page Block RichText Headings
 @mixin ftva-fpb-rich-text-h3 {
   font-family: $font-primary;
   font-size: 36px;


### PR DESCRIPTION
Connected to: [APPS-3442](https://uclalibrary.atlassian.net/browse/APPS-3442)

I added a comment so [PR-155](https://github.com/UCLALibrary/design-tokens/pull/155) will be added to the build & release. When I previously submitted [PR-155](https://github.com/UCLALibrary/design-tokens/pull/155) I had used `style:` as a conventional commit prefix which does not triggered a build.

---

This is [PR-155](https://github.com/UCLALibrary/design-tokens/pull/155) 

This PR adds specific styles for the FPB rich text h3,h4,& h5 headings.
It will be included on the FTVA pages the have FPBs

```css

@mixin ftva-fpb-rich-text-h3 {
  font-family: $font-primary;
  font-size: 36px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h4 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-medium;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h5 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}
```

<img width="883" height="422" alt="Screenshot 2025-10-01 at 5 16 23 PM" src="https://github.com/user-attachments/assets/0186097e-9335-4354-89be-0f0be2afa65c" />
