### PR TITLE
feat: move styles for ftva-fpb rich text h3 h4 h5 to the bottom of the page

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -187,28 +187,6 @@
   line-height: 110%;
 }
 
-// Flexible Page Block RichText Headings
-@mixin ftva-fpb-rich-text-h3 {
-  font-family: $font-primary;
-  font-size: 36px;
-  font-weight: $font-weight-regular;
-  line-height: 110%;
-}
-
-@mixin ftva-fpb-rich-text-h4 {
-  font-family: $font-primary;
-  font-size: 28px;
-  font-weight: $font-weight-medium;
-  line-height: 110%;
-}
-
-@mixin ftva-fpb-rich-text-h5 {
-  font-family: $font-primary;
-  font-size: 28px;
-  font-weight: $font-weight-regular;
-  line-height: 110%;
-}
-
 @mixin ftva-card-title-1 {
   font-family: $font-primary;
   font-size: 30px;
@@ -370,4 +348,26 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: $lines;
+}
+
+// Flexible Page Block RichText Headings
+@mixin ftva-fpb-rich-text-h3 {
+  font-family: $font-primary;
+  font-size: 36px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h4 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-medium;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h5 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
 }


### PR DESCRIPTION
Connected to: [APPS-3442](https://uclalibrary.atlassian.net/browse/APPS-3442)

I moved the styles to the bottom of the page so the build will be triggered.
This PR didn't have enough changed to trigger it:
https://github.com/UCLALibrary/design-tokens/pull/156

---

This is [PR-155](https://github.com/UCLALibrary/design-tokens/pull/155) 

This PR adds specific styles for the FPB rich text h3,h4,& h5 headings.
It will be included on the FTVA pages that have FPBs

```css

@mixin ftva-fpb-rich-text-h3 {
  font-family: $font-primary;
  font-size: 36px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h4 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-medium;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h5 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}
```


[APPS-3442]: https://uclalibrary.atlassian.net/browse/APPS-3442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PR-155]: https://uclalibrary.atlassian.net/browse/PR-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ