### PR TITLE
feat: APPS-3031 Update headings sizes and styling for fpb richtext

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -187,6 +187,28 @@
   line-height: 110%;
 }
 
+// Flexible Page Block RichText Headings
+@mixin ftva-fpb-rich-text-h3 {
+  font-family: $font-primary;
+  font-size: 36px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h4 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-medium;
+  line-height: 110%;
+}
+
+@mixin ftva-fpb-rich-text-h5 {
+  font-family: $font-primary;
+  font-size: 28px;
+  font-weight: $font-weight-regular;
+  line-height: 110%;
+}
+
 @mixin ftva-card-title-1 {
   font-family: $font-primary;
   font-size: 30px;
@@ -348,26 +370,4 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: $lines;
-}
-
-// Flexible Page Block RichText Headings
-@mixin ftva-fpb-rich-text-h3 {
-  font-family: $font-primary;
-  font-size: 36px;
-  font-weight: $font-weight-regular;
-  line-height: 110%;
-}
-
-@mixin ftva-fpb-rich-text-h4 {
-  font-family: $font-primary;
-  font-size: 28px;
-  font-weight: $font-weight-medium;
-  line-height: 110%;
-}
-
-@mixin ftva-fpb-rich-text-h5 {
-  font-family: $font-primary;
-  font-size: 28px;
-  font-weight: $font-weight-regular;
-  line-height: 110%;
 }


### PR DESCRIPTION
Connected to: [APPS-3442](https://uclalibrary.atlassian.net/browse/APPS-3442)

- The commit must be in the conventional commit format to trigger the build ie: `git commit -m 'feat: update headings sizes and styling for fpb richtext'`
- Just having the title on github's PR page be a conventional commit `feat: ...` does not trigger a build.

---

This PR adds specific styles for the FPB rich text h3,h4,& h5 headings.
It will be included on the FTVA pages that have FPBs

```css

@mixin ftva-fpb-rich-text-h3 {
  font-family: $font-primary;
  font-size: 36px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h4 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-medium;
  line-height: 110%;
}

@mixin ftva-fpb-rich-text-h5 {
  font-family: $font-primary;
  font-size: 28px;
  font-weight: $font-weight-regular;
  line-height: 110%;
}
```

[APPS-3442]: https://uclalibrary.atlassian.net/browse/APPS-3442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ