### PR TITLE
feat: APPS-3480 FPB rich-text multi-line ordered & unordered list items should have the same indentation on each line

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -209,6 +209,28 @@
   line-height: 110%;
 }
 
+@mixin ftva-fpb-rich-text-ul {
+  ul {
+    padding: 0;
+
+    li {
+      position: relative;
+      padding-left: calc(1rem + 22px);
+
+      &::before {
+        position: absolute;
+        margin-left: calc(-1rem - 22px);
+      }
+    }
+  }
+}
+
+@mixin ftva-fpb-rich-text-ol {
+  ol {
+    padding: 0;
+  }
+}
+
 @mixin ftva-card-title-1 {
   font-family: $font-primary;
   font-size: 30px;


### PR DESCRIPTION
Connected to [APPS-3480](https://uclalibrary.atlassian.net/browse/APPS-3480)

Create mixin for FTVA FPB RichText Ordered & Unordered lists.
If the list item is multi-lined; all lines will have the same indentation.

<img width="1005" height="427" alt="Screenshot 2025-10-09 at 7 54 32 PM" src="https://github.com/user-attachments/assets/4f81a61c-5609-47ec-8c24-aef3dfe8c937" />


[APPS-3480]: https://uclalibrary.atlassian.net/browse/APPS-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ