### PR TITLE
feat: update styling for ftva-card-title-1

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -306,9 +306,8 @@
 }
 
 @mixin ftva-text-link-hover {
-  @include ftva-button-link;
   text-decoration: underline;
-  text-decoration-thickness: 2px;
+  text-decoration-thickness: 3px;
   text-decoration-color: $bright-blue;
   text-underline-offset: 2px;
 }
@@ -382,9 +381,10 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: $lines;
 }
- @mixin ftva-wrapper-title {
-    color: $heading-grey;
-    font-size: var(--step-4);
-    font-family: $font-primary;
-    font-weight: 400;
- }
+
+@mixin ftva-wrapper-title {
+  color: $heading-grey;
+  font-size: var(--step-4);
+  font-family: $font-primary;
+  font-weight: 400;
+}


### PR DESCRIPTION
This helper for the hover style was not being used because it was the wrong styling it is now updated.
```
@mixin ftva-text-link-hover {
  text-decoration: underline;
  text-decoration-thickness: 3px;
  text-decoration-color: $bright-blue;
  text-underline-offset: 2px;
}
```

### `@include ftva-text-link-hover` looks like this:

<img width="342" height="515" alt="Screenshot 2026-01-08 at 1 32 10 PM" src="https://github.com/user-attachments/assets/4ddec65b-42f0-4be4-b029-1a6767909aaa" />
