### PR TITLE
fix: Change Figma Tokens plugin to Token Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Design tokens for UCLA Library.
 
-The **Design Tokens** repository stores and syncs design tokens from the UCLA Library Design System using the [Figma Tokens plugin](https://docs.tokens.studio/) and GitHub Actions to generate Sass variables for use as an [NPM package](https://www.npmjs.com/package/ucla-library-design-tokens).
+The **Design Tokens** repository stores and syncs design tokens from the UCLA Library Design System using the [Token Studio plugin](https://docs.tokens.studio/) and GitHub Actions to generate Sass variables for use as an [NPM package](https://www.npmjs.com/package/ucla-library-design-tokens).
 
 ## What are Design Tokens?
 


### PR DESCRIPTION
Updated the plugin reference from Figma Tokens to Token Studio. (to trigger a release)